### PR TITLE
ContextApp can now run cobertura as well, was giving an error before

### DIFF
--- a/ContextApp/pom.xml
+++ b/ContextApp/pom.xml
@@ -13,7 +13,6 @@
 	<packaging>apk</packaging>
 
 	<repositories>
-	
 		<repository>
 			<id>local-repo</id>
 			<name>Local Repository</name>
@@ -102,9 +101,7 @@
     
  
 	<build>
-	
-		<plugins>
-		
+		<plugins>			
 			<plugin>
 				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
@@ -261,13 +258,13 @@
     </build>
 	
 	<reporting>
-		<plugins>
-            <plugin>
+		<plugins>	
+		    <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.6</version>
             </plugin>
-            
+		        
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
Android didn't like version 2.7 of cobertura, so mvn site would fail.
With version 2.6 it does work again.
