### PR TITLE
the commander camera is placed higher.

### DIFF
--- a/ContextDesktop/src/main/java/com/github/migi_1/Context/model/MainEnvironment.java
+++ b/ContextDesktop/src/main/java/com/github/migi_1/Context/model/MainEnvironment.java
@@ -58,8 +58,8 @@ public class MainEnvironment extends Environment {
     private static final Vector3f WORLD_LOCATION = new Vector3f(300, -20, 0);
 
     private static final Vector3f PLATFORM_LOCATION = new Vector3f(20, -18, -1);
-    private static final Vector3f COMMANDER_LOCATION = new Vector3f(23, -14, -1f);
-    private static final Vector3f RELATIVE_CARRIER_LOCATION = new Vector3f(-4f, -3.5f, 6f);
+    private static final Vector3f COMMANDER_LOCATION = new Vector3f(23, -10, -1f);
+    private static final Vector3f RELATIVE_CARRIER_LOCATION = new Vector3f(-4f, -7.5f, 6f);
 
     private static final float COMMANDER_ROTATION = -1.5f;
 


### PR DESCRIPTION
This is based on input from playtesting.
It allows the Oculus Rift user to more easily see the enemies attacking the carriers.
